### PR TITLE
`rustfmt` + `Multihash: Hash`

### DIFF
--- a/src/mh.rs
+++ b/src/mh.rs
@@ -6,6 +6,7 @@ use multibase::Base;
 use multicodec::Codec;
 use multitrait::{Null, TryDecodeFrom};
 use multiutil::{BaseEncoded, CodecInfo, DetectedEncoder, EncodingInfo, Varbytes};
+use std::hash::Hash;
 use typenum::consts::*;
 
 /// the hash codecs currently supported
@@ -32,7 +33,8 @@ pub const HASH_CODECS: [Codec; 23] = [
     Codec::Sha3224,
     Codec::Sha3256,
     Codec::Sha3384,
-    Codec::Sha3512];
+    Codec::Sha3512,
+];
 
 /// the safe hash codecs current supported
 pub const SAFE_HASH_CODECS: [Codec; 8] = [
@@ -43,7 +45,8 @@ pub const SAFE_HASH_CODECS: [Codec; 8] = [
     Codec::Blake3,
     Codec::Sha3256,
     Codec::Sha3384,
-    Codec::Sha3512];
+    Codec::Sha3512,
+];
 
 /// the multicodec sigil for multihash
 pub const SIGIL: Codec = Codec::Multihash;
@@ -52,7 +55,7 @@ pub const SIGIL: Codec = Codec::Multihash;
 pub type EncodedMultihash = BaseEncoded<Multihash, DetectedEncoder>;
 
 /// inner implementation of the multihash
-#[derive(Clone, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Default, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct Multihash {
     /// hash codec
     pub(crate) codec: Codec,
@@ -334,7 +337,12 @@ mod tests {
             .unwrap()
             .try_build()
             .unwrap();
-        let mh2 = Multihash::try_from(hex::decode("16206b761d3b2e7675e088e337a82207b55711d3957efdb877a3d261b0ca2c38e201").unwrap().as_ref()).unwrap();
+        let mh2 = Multihash::try_from(
+            hex::decode("16206b761d3b2e7675e088e337a82207b55711d3957efdb877a3d261b0ca2c38e201")
+                .unwrap()
+                .as_ref(),
+        )
+        .unwrap();
         assert_eq!(mh1, mh2);
     }
 
@@ -351,7 +359,10 @@ mod tests {
     fn test_multihash_sha1() {
         // test cases from: https://github.com/multiformats/multihash?tab=readme-ov-file#example
         let bases = vec![
-            (Base::Base16Lower, "f111488c2f11fb2ce392acb5b2986e640211c4690073e"),
+            (
+                Base::Base16Lower,
+                "f111488c2f11fb2ce392acb5b2986e640211c4690073e",
+            ),
             (Base::Base32Upper, "BCEKIRQXRD6ZM4OJKZNNSTBXGIAQRYRUQA47A"),
             (Base::Base58Btc, "z5dsgvJGnvAfiR3K6HCBc4hcokSfmjj"),
             (Base::Base64, "mERSIwvEfss45KstbKYbmQCEcRpAHPg"),
@@ -372,10 +383,22 @@ mod tests {
     fn test_multihash_sha2_256() {
         // test cases from: https://github.com/multiformats/multihash?tab=readme-ov-file#example
         let bases = vec![
-            (Base::Base16Lower, "f12209cbc07c3f991725836a3aa2a581ca2029198aa420b9d99bc0e131d9f3e2cbe47"),
-            (Base::Base32Upper, "BCIQJZPAHYP4ZC4SYG2R2UKSYDSRAFEMYVJBAXHMZXQHBGHM7HYWL4RY"),
-            (Base::Base58Btc, "zQmYtUc4iTCbbfVSDNKvtQqrfyezPPnFvE33wFmutw9PBBk"),
-            (Base::Base64, "mEiCcvAfD+ZFyWDajqipYHKICkZiqQgudmbwOEx2fPiy+Rw"),
+            (
+                Base::Base16Lower,
+                "f12209cbc07c3f991725836a3aa2a581ca2029198aa420b9d99bc0e131d9f3e2cbe47",
+            ),
+            (
+                Base::Base32Upper,
+                "BCIQJZPAHYP4ZC4SYG2R2UKSYDSRAFEMYVJBAXHMZXQHBGHM7HYWL4RY",
+            ),
+            (
+                Base::Base58Btc,
+                "zQmYtUc4iTCbbfVSDNKvtQqrfyezPPnFvE33wFmutw9PBBk",
+            ),
+            (
+                Base::Base64,
+                "mEiCcvAfD+ZFyWDajqipYHKICkZiqQgudmbwOEx2fPiy+Rw",
+            ),
         ];
 
         for (b, h) in bases {
@@ -389,4 +412,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_multihash_in_indexmap() {
+        let mut map = std::collections::HashMap::new();
+
+        let mh1 = Builder::new_from_bytes(Codec::Sha2256, b"for great justice, move every zig!")
+            .unwrap()
+            .try_build()
+            .unwrap();
+
+        let mh2 = Builder::new_from_bytes(Codec::Sha2256, b"for great justice, move every zag!")
+            .unwrap()
+            .try_build()
+            .unwrap();
+
+        map.insert(mh1, "zig");
+        map.insert(mh2, "zag");
+
+        assert_eq!(map.len(), 2);
+    }
 }


### PR DESCRIPTION
There's a lot of `rustfmt` noise in there, but this is mostly just:

```rust
#[derive(Hash)]
pub struct Multihash {
```

plus a test

fixes #1 